### PR TITLE
Deprecated TFA + moved all necessary classes/methods into gcvit

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ Here is grad-cam result after training on Flower Classification Dataset,
 
 
 ## To Do
-- [ ] Remove `tensorflow_addons`
 - [ ] Segmentation Pipeline
 - [ ] Support for `Kaggle Models`
+- [x] Remove `tensorflow_addons`
 - [x] New updated weights have been added.
 - [x] Working training example in Colab & Kaggle.
 - [x] GradCAM showcase.

--- a/gcvit/__init__.py
+++ b/gcvit/__init__.py
@@ -5,4 +5,5 @@ from .models import GCViTSmall
 from .models import GCViTTiny
 from .models import GCViTXTiny
 from .models import GCViTXXTiny
+from .utils import conv_utils
 from .version import __version__

--- a/gcvit/layers/__init__.py
+++ b/gcvit/layers/__init__.py
@@ -9,5 +9,6 @@ from .feature import Mlp
 from .feature import ReduceSize
 from .feature import Resizing
 from .level import GCViTLevel
+from .pooling import AdaptiveAveragePooling2D
 from .window import window_partition
 from .window import window_reverse

--- a/gcvit/layers/feature.py
+++ b/gcvit/layers/feature.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
-import tensorflow_addons as tfa
+
+from .pooling import AdaptiveAveragePooling2D
 
 H_AXIS = -3
 W_AXIS = -2
@@ -63,7 +64,7 @@ class SE(tf.keras.layers.Layer):
     def build(self, input_shape):
         inp = input_shape[-1]
         self.oup = self.oup or inp
-        self.avg_pool = tfa.layers.AdaptiveAveragePooling2D(1, name="avg_pool")
+        self.avg_pool = AdaptiveAveragePooling2D(1, name="avg_pool")
         self.fc = [
             tf.keras.layers.Dense(
                 int(inp * self.expansion), use_bias=False, name="fc/0"

--- a/gcvit/layers/pooling.py
+++ b/gcvit/layers/pooling.py
@@ -13,9 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import Callable
+from typing import Iterable
+from typing import Union
+
 import tensorflow as tf
-from tensorflow.keras.utils import conv_utils
-from typing import Union, Callable, Iterable
+
+from ..utils import normalize_data_format
+from ..utils import normalize_tuple
 
 
 @tf.keras.utils.register_keras_serializable(package="gcvit")
@@ -29,8 +34,8 @@ class AdaptivePooling2D(tf.keras.layers.Layer):
 
     Args:
       reduce_function: The reduction method to apply, e.g. `tf.reduce_max`.
-      output_size: An integer or tuple/list of 2 integers specifying (pooled_rows, pooled_cols).
-        The new size of output channels.
+      output_size: An integer or tuple/list of 2 integers specifying
+        (pooled_rows, pooled_cols). The new size of output channels.
       data_format: A string,
         one of `channels_last` (default) or `channels_first`.
         The ordering of the dimensions in the inputs.
@@ -47,9 +52,9 @@ class AdaptivePooling2D(tf.keras.layers.Layer):
         data_format=None,
         **kwargs,
     ):
-        self.data_format = conv_utils.normalize_data_format(data_format)
+        self.data_format = normalize_data_format(data_format)
         self.reduce_function = reduce_function
-        self.output_size = conv_utils.normalize_tuple(output_size, 2, "output_size")
+        self.output_size = normalize_tuple(output_size, 2, "output_size")
         super().__init__(**kwargs)
 
     def call(self, inputs, *args):

--- a/gcvit/layers/pooling.py
+++ b/gcvit/layers/pooling.py
@@ -1,0 +1,137 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import tensorflow as tf
+from tensorflow.keras.utils import conv_utils
+from typing import Union, Callable, Iterable
+
+
+@tf.keras.utils.register_keras_serializable(package="gcvit")
+class AdaptivePooling2D(tf.keras.layers.Layer):
+    """Parent class for 2D pooling layers with adaptive kernel size.
+
+    Implementation is based on tensorflow-addons:
+    https://github.com/tensorflow/addons/blob/v0.17.0/tensorflow_addons/layers/adaptive_pooling.py#LL157C1-L234C41
+
+    This class only exists for code reuse. It will never be an exposed API.
+
+    Args:
+      reduce_function: The reduction method to apply, e.g. `tf.reduce_max`.
+      output_size: An integer or tuple/list of 2 integers specifying (pooled_rows, pooled_cols).
+        The new size of output channels.
+      data_format: A string,
+        one of `channels_last` (default) or `channels_first`.
+        The ordering of the dimensions in the inputs.
+        `channels_last` corresponds to inputs with shape
+        `(batch, height, width, channels)` while `channels_first`
+        corresponds to inputs with shape
+        `(batch, channels, height, width)`.
+    """
+
+    def __init__(
+        self,
+        reduce_function: Callable,
+        output_size: Union[int, Iterable[int]],
+        data_format=None,
+        **kwargs,
+    ):
+        self.data_format = conv_utils.normalize_data_format(data_format)
+        self.reduce_function = reduce_function
+        self.output_size = conv_utils.normalize_tuple(output_size, 2, "output_size")
+        super().__init__(**kwargs)
+
+    def call(self, inputs, *args):
+        h_bins = self.output_size[0]
+        w_bins = self.output_size[1]
+        if self.data_format == "channels_last":
+            split_cols = tf.split(inputs, h_bins, axis=1)
+            split_cols = tf.stack(split_cols, axis=1)
+            split_rows = tf.split(split_cols, w_bins, axis=3)
+            split_rows = tf.stack(split_rows, axis=3)
+            out_vect = self.reduce_function(split_rows, axis=[2, 4])
+        else:
+            split_cols = tf.split(inputs, h_bins, axis=2)
+            split_cols = tf.stack(split_cols, axis=2)
+            split_rows = tf.split(split_cols, w_bins, axis=4)
+            split_rows = tf.stack(split_rows, axis=4)
+            out_vect = self.reduce_function(split_rows, axis=[3, 5])
+        return out_vect
+
+    def compute_output_shape(self, input_shape):
+        input_shape = tf.TensorShape(input_shape).as_list()
+        if self.data_format == "channels_last":
+            shape = tf.TensorShape(
+                [
+                    input_shape[0],
+                    self.output_size[0],
+                    self.output_size[1],
+                    input_shape[3],
+                ]
+            )
+        else:
+            shape = tf.TensorShape(
+                [
+                    input_shape[0],
+                    input_shape[1],
+                    self.output_size[0],
+                    self.output_size[1],
+                ]
+            )
+
+        return shape
+
+    def get_config(self):
+        config = {
+            "output_size": self.output_size,
+            "data_format": self.data_format,
+        }
+        base_config = super().get_config()
+        return {**base_config, **config}
+
+
+@tf.keras.utils.register_keras_serializable(package="gcvit")
+class AdaptiveAveragePooling2D(AdaptivePooling2D):
+    """Average Pooling with adaptive kernel size.
+
+    Class is borrowed from tensorflow-addons:
+    https://github.com/tensorflow/addons/blob/v0.17.0/tensorflow_addons/layers/adaptive_pooling.py#L238
+
+    Args:
+      output_size: Tuple of integers specifying (pooled_rows, pooled_cols).
+        The new size of output channels.
+      data_format: A string,
+        one of `channels_last` (default) or `channels_first`.
+        The ordering of the dimensions in the inputs.
+        `channels_last` corresponds to inputs with shape
+        `(batch, height, width, channels)` while `channels_first`
+        corresponds to inputs with shape `(batch, channels, height, width)`.
+
+    Input shape:
+      - If `data_format='channels_last'`:
+        4D tensor with shape `(batch_size, height, width, channels)`.
+      - If `data_format='channels_first'`:
+        4D tensor with shape `(batch_size, channels, height, width)`.
+
+    Output shape:
+      - If `data_format='channels_last'`:
+        4D tensor with shape `(batch_size, pooled_rows, pooled_cols, channels)`.
+      - If `data_format='channels_first'`:
+        4D tensor with shape `(batch_size, channels, pooled_rows, pooled_cols)`.
+    """
+
+    def __init__(
+        self, output_size: Union[int, Iterable[int]], data_format=None, **kwargs
+    ):
+        super().__init__(tf.reduce_mean, output_size, data_format, **kwargs)

--- a/gcvit/utils/__init__.py
+++ b/gcvit/utils/__init__.py
@@ -1,3 +1,5 @@
+from .conv_utils import normalize_data_format
+from .conv_utils import normalize_tuple
 from .gradcam import get_gradcam_model
 from .gradcam import get_gradcam_prediction
 from .gradcam import process_image

--- a/gcvit/utils/conv_utils.py
+++ b/gcvit/utils/conv_utils.py
@@ -1,0 +1,97 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from tensorflow.keras import backend
+
+
+def normalize_tuple(value, n, name, allow_zero=False):
+    """Transforms non-negative/positive integer/integers into an integer tuple.
+
+    Borrowed from Keras:
+    https://github.com/keras-team/keras/blob/ab02bd5c8d75a9c8cc9f78cc7cdb5e7a01307588/keras/utils/conv_utils.py#L57
+
+    Args:
+      value: The value to validate and convert. Could an int, or any iterable of
+        ints.
+      n: The size of the tuple to be returned.
+      name: The name of the argument being validated, e.g. "strides" or
+        "kernel_size". This is only used to format error messages.
+      allow_zero: Default to False. A ValueError will raised if zero is received
+        and this param is False.
+
+    Returns:
+      A tuple of n integers.
+
+    Raises:
+      ValueError: If something else than an int/long or iterable thereof or a
+      negative value is
+        passed.
+    """
+    error_msg = (
+        f"The `{name}` argument must be a tuple of {n} "
+        f"integers. Received: {value}"
+    )
+
+    if isinstance(value, int):
+        value_tuple = (value,) * n
+    else:
+        try:
+            value_tuple = tuple(value)
+        except TypeError:
+            raise ValueError(error_msg)
+        if len(value_tuple) != n:
+            raise ValueError(error_msg)
+        for single_value in value_tuple:
+            try:
+                int(single_value)
+            except (ValueError, TypeError):
+                error_msg += (
+                    f"including element {single_value} of "
+                    f"type {type(single_value)}"
+                )
+                raise ValueError(error_msg)
+
+    if allow_zero:
+        unqualified_values = {v for v in value_tuple if v < 0}
+        req_msg = ">= 0"
+    else:
+        unqualified_values = {v for v in value_tuple if v <= 0}
+        req_msg = "> 0"
+
+    if unqualified_values:
+        error_msg += (
+            f" including {unqualified_values}"
+            f" that does not satisfy the requirement `{req_msg}`."
+        )
+        raise ValueError(error_msg)
+
+    return value_tuple
+
+
+def normalize_data_format(value):
+    """Transforms image data format to fixed format if possible.
+
+    Borrowed from Keras:
+    https://github.com/keras-team/keras/blob/ab02bd5c8d75a9c8cc9f78cc7cdb5e7a01307588/keras/utils/conv_utils.py#L220
+    """
+    if value is None:
+        value = backend.image_data_format()
+    data_format = value.lower()
+    if data_format not in {"channels_first", "channels_last"}:
+        raise ValueError(
+            "The `data_format` argument must be one of "
+            f'"channels_first", "channels_last". Received: {value}'
+        )
+    return data_format

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-tensorflow
 typing
 gradio
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# tensorflow==2.4.1
-tensorflow_addons
+tensorflow
+typing
 gradio
 numpy
 matplotlib


### PR DESCRIPTION
As discussed in PR https://github.com/awsaf49/gcvit-tf/pull/8, it would be smart to remove `tensorflow-addons` as it will be sunset.

I have therefore moved the necessary two classes from `tfa` into the project. Two methods from `tfa.keras.utils.conv_utils` had been moved to `keras` for `keras==2.10`. However, to preserve backward compatibility for older `tensorflow` versions, I added the implementations directly here. Note that I have kept the license at the top, as we borrowed these classes/methods from `keras/tf-addons`.

Note that I added `typing` as a small dependency for typehints. Typehints should likely be added for all classes and methods in the future.

A natural next step is to add unit tests, as adding modifications like these may result in issue for different `tf` versions or similar. However, adding proper tests take time, so a separate PR would likely be better.

Note that I have done some simple testing locally verifying that it works, but CIs would be better. Shall a make a go at it next?