### PR TITLE
Run PyPI CI on tag creation only

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,7 +1,9 @@
 name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+    - '*'
 
 jobs:
   build-n-publish:
@@ -13,6 +15,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
+
     - name: Install pypa/build
       run: >-
         python -m


### PR DESCRIPTION
Because of [this](https://github.com/awsaf49/gcvit-tf/blob/fa5cd35f142ad6d7d97c15578719c59236de8229/.github/workflows/publish_to_pypi.yml#L33) line, the release will never be published as the current CI can only be ran through dispatch, which is not necessarily linked to a tag. Did not notice it when I proposed the change.

Previously this CI was ran for **all** commits, but now I changed it to only be ran on tag creation, which is likely what you wanted to do from the beginning.